### PR TITLE
[feat] 웹툰 검색 API 연동

### DIFF
--- a/app/src/main/java/com/example/kakaowebtoon/data/dataremote/datasource/WebtoonsRemoteDataSource.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/data/dataremote/datasource/WebtoonsRemoteDataSource.kt
@@ -1,0 +1,7 @@
+package com.example.kakaowebtoon.data.dataremote.datasource
+
+import com.example.kakaowebtoon.data.dataremote.model.response.WebtoonsResponseDto
+
+interface WebtoonsRemoteDataSource {
+    suspend fun searchWebtoons(title: String): WebtoonsResponseDto
+}

--- a/app/src/main/java/com/example/kakaowebtoon/data/dataremote/datasourceimpl/WebtoonsRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/data/dataremote/datasourceimpl/WebtoonsRemoteDataSourceImpl.kt
@@ -1,0 +1,13 @@
+package com.example.kakaowebtoon.data.dataremote.datasourceimpl
+
+import com.example.kakaowebtoon.data.dataremote.datasource.WebtoonsRemoteDataSource
+import com.example.kakaowebtoon.data.dataremote.model.response.WebtoonsResponseDto
+import com.example.kakaowebtoon.data.dataremote.service.WebtoonsService
+import javax.inject.Inject
+
+class WebtoonsRemoteDataSourceImpl @Inject constructor(
+    private val service: WebtoonsService
+) : WebtoonsRemoteDataSource {
+    override suspend fun searchWebtoons(title: String): WebtoonsResponseDto =
+        service.searchWebtoons(title = title)
+}

--- a/app/src/main/java/com/example/kakaowebtoon/data/dataremote/model/response/DayWebtoonsResponseDto.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/data/dataremote/model/response/DayWebtoonsResponseDto.kt
@@ -1,0 +1,22 @@
+package com.example.kakaowebtoon.data.dataremote.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DayWebtoonsResponseDto(
+    @SerialName("status") val status: Int,
+    @SerialName("data") val data: DayWebtoonsData
+)
+
+@Serializable
+data class DayWebtoonsData(
+    @SerialName("webtoons") val webtoons: List<DayWebtoon>
+)
+
+@Serializable
+data class DayWebtoon(
+    @SerialName("id") val id: Int,
+    @SerialName("title") val title: String,
+    @SerialName("image") val image: String
+)

--- a/app/src/main/java/com/example/kakaowebtoon/data/dataremote/model/response/WebtoonsResponseDto.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/data/dataremote/model/response/WebtoonsResponseDto.kt
@@ -1,0 +1,24 @@
+package com.example.kakaowebtoon.data.dataremote.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WebtoonsResponseDto(
+    @SerialName("status") val status: Int,
+    @SerialName("data") val data: WebtoonsData
+)
+
+@Serializable
+data class WebtoonsData(
+    @SerialName("webtoons") val webtoons: List<Webtoon>
+)
+
+@Serializable
+data class Webtoon(
+    @SerialName("title") val title: String,
+    @SerialName("author") val author: String,
+    @SerialName("image") val image: String?,
+    @SerialName("genre") val genre: String,
+    @SerialName("promotion") val promotion: String
+)

--- a/app/src/main/java/com/example/kakaowebtoon/data/dataremote/service/EpisodeService.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/data/dataremote/service/EpisodeService.kt
@@ -1,0 +1,9 @@
+package com.example.kakaowebtoon.data.dataremote.service
+
+import com.example.kakaowebtoon.data.dataremote.model.response.DummyResponseDto
+import retrofit2.http.POST
+
+interface EpisodeService {
+    @POST("/API")
+    suspend fun funName(): List<DummyResponseDto>
+}

--- a/app/src/main/java/com/example/kakaowebtoon/data/dataremote/service/WebtoonsService.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/data/dataremote/service/WebtoonsService.kt
@@ -1,0 +1,12 @@
+package com.example.kakaowebtoon.data.dataremote.service
+
+import com.example.kakaowebtoon.data.dataremote.model.response.WebtoonsResponseDto
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface WebtoonsService {
+    @GET("/api/v1/webtoons/search")
+    suspend fun searchWebtoons(
+        @Query("title") title: String
+    ): WebtoonsResponseDto
+}

--- a/app/src/main/java/com/example/kakaowebtoon/data/repositoryimpl/WebtoonsRepositoryImpl.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/data/repositoryimpl/WebtoonsRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.example.kakaowebtoon.data.repositoryimpl
+
+import com.example.kakaowebtoon.data.dataremote.datasource.WebtoonsRemoteDataSource
+import com.example.kakaowebtoon.data.dataremote.model.response.WebtoonsResponseDto
+import com.example.kakaowebtoon.domain.repository.WebtoonsRepository
+import jakarta.inject.Inject
+
+class WebtoonsRepositoryImpl @Inject constructor(
+    private val webtoonsRemoteDataSource: WebtoonsRemoteDataSource
+) : WebtoonsRepository {
+    override suspend fun searchWebtoons(title: String): Result<WebtoonsResponseDto> = runCatching {
+        webtoonsRemoteDataSource.searchWebtoons(title = title)
+    }
+}

--- a/app/src/main/java/com/example/kakaowebtoon/di/DataSourceModule.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/di/DataSourceModule.kt
@@ -3,7 +3,9 @@ package com.example.kakaowebtoon.di
 import com.example.kakaowebtoon.data.datalocal.datasource.DummyLocalDataSource
 import com.example.kakaowebtoon.data.datalocal.datasourceimpl.DummyLocalDataSourceImpl
 import com.example.kakaowebtoon.data.dataremote.datasource.DummyRemoteDataSource
+import com.example.kakaowebtoon.data.dataremote.datasource.WebtoonsRemoteDataSource
 import com.example.kakaowebtoon.data.dataremote.datasourceimpl.DummyRemoteDataSourceImpl
+import com.example.kakaowebtoon.data.dataremote.datasourceimpl.WebtoonsRemoteDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -20,4 +22,8 @@ abstract class DataSourceModule {
     @Binds
     @Singleton
     abstract fun bindsDummyLocalDataSource(dummyLocalDataSourceImpl: DummyLocalDataSourceImpl): DummyLocalDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindsWebtoonsLocalDataSource(webtoonsRemoteDataSourceImpl: WebtoonsRemoteDataSourceImpl): WebtoonsRemoteDataSource
 }

--- a/app/src/main/java/com/example/kakaowebtoon/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.example.kakaowebtoon.di
 
 import com.example.kakaowebtoon.data.repositoryimpl.DummyRepositoryImpl
+import com.example.kakaowebtoon.data.repositoryimpl.WebtoonsRepositoryImpl
 import com.example.kakaowebtoon.domain.repository.DummyRepository
+import com.example.kakaowebtoon.domain.repository.WebtoonsRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,4 +16,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindDummyRepository(dummyRepositoryImpl: DummyRepositoryImpl): DummyRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindWebtoonsRepository(webtoonsRepositoryImpl: WebtoonsRepositoryImpl): WebtoonsRepository
 }

--- a/app/src/main/java/com/example/kakaowebtoon/di/ServiceModule.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/di/ServiceModule.kt
@@ -1,6 +1,7 @@
 package com.example.kakaowebtoon.di
 
 import com.example.kakaowebtoon.data.dataremote.service.DummyService
+import com.example.kakaowebtoon.data.dataremote.service.WebtoonsService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -15,4 +16,9 @@ object ServiceModule {
     @Singleton
     fun providesService(retrofit: Retrofit): DummyService =
         retrofit.create(DummyService::class.java)
+
+    @Provides
+    @Singleton
+    fun providesWebtoonsService(retrofit: Retrofit): WebtoonsService =
+        retrofit.create(WebtoonsService::class.java)
 }

--- a/app/src/main/java/com/example/kakaowebtoon/domain/repository/WebtoonsRepository.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/domain/repository/WebtoonsRepository.kt
@@ -1,0 +1,7 @@
+package com.example.kakaowebtoon.domain.repository
+
+import com.example.kakaowebtoon.data.dataremote.model.response.WebtoonsResponseDto
+
+interface WebtoonsRepository {
+    suspend fun searchWebtoons(title: String): Result<WebtoonsResponseDto>
+}

--- a/app/src/main/java/com/example/kakaowebtoon/domain/usecase/SearchWebtoonsUseCase.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/domain/usecase/SearchWebtoonsUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.kakaowebtoon.domain.usecase
+
+import com.example.kakaowebtoon.domain.repository.WebtoonsRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SearchWebtoonsUseCase @Inject constructor(
+    private val webtoonsRepository: WebtoonsRepository
+) {
+    suspend operator fun invoke(title: String) = webtoonsRepository.searchWebtoons(title = title)
+}

--- a/app/src/main/java/com/example/kakaowebtoon/presentation/ui/component/card/KakaoWebtoonCard.kt
+++ b/app/src/main/java/com/example/kakaowebtoon/presentation/ui/component/card/KakaoWebtoonCard.kt
@@ -1,17 +1,24 @@
 package com.example.kakaowebtoon.presentation.ui.component.card
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.example.kakaowebtoon.R
 import com.example.kakaowebtoon.domain.model.WebtoonCard
 import com.example.kakaowebtoon.domain.util.Promotion
 import com.example.kakaowebtoon.presentation.ui.component.tags.KakaoWebtoonClockTag
@@ -31,10 +38,26 @@ fun KakaoWebtoonCard(
         modifier = modifier
             .height(IntrinsicSize.Min)
     ) {
-        AsyncImage(
-            model = card.imageUrl,
-            contentDescription = null
-        )
+        if (card.imageUrl.isNotEmpty()) {
+            AsyncImage(
+                model = card.imageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .width(LocalConfiguration.current.screenWidthDp.dp * (150f / 360f))
+                    .aspectRatio(150f / 95f)
+            )
+        } else {
+            Image(
+                imageVector = ImageVector.vectorResource(R.drawable.img_empty_webtoon_card),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .width(LocalConfiguration.current.screenWidthDp.dp * (150f / 360f))
+                    .aspectRatio(150f / 95f)
+            )
+        }
+
         Spacer(modifier = modifier.width(12.dp))
 
         Column {

--- a/app/src/main/res/drawable/img_empty_webtoon_card.xml
+++ b/app/src/main/res/drawable/img_empty_webtoon_card.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="150dp"
+    android:height="95dp"
+    android:viewportWidth="150"
+    android:viewportHeight="95">
+  <path
+      android:pathData="M5,0L145,0A5,5 0,0 1,150 5L150,90A5,5 0,0 1,145 95L5,95A5,5 0,0 1,0 90L0,5A5,5 0,0 1,5 0z"
+      android:fillColor="#F8D447"/>
+  <group>
+    <clip-path
+        android:pathData="M58,41h35v13h-35z"/>
+    <path
+        android:pathData="M64,41H58V54H64V41Z"
+        android:fillColor="#4C4C4C"/>
+    <path
+        android:pathData="M64,54H70.13L75,41H68.87L64,54Z"
+        android:fillColor="#4C4C4C"
+        android:fillType="evenOdd"/>
+    <path
+        android:pathData="M93,41H87V54H93V41Z"
+        android:fillColor="#4C4C4C"/>
+    <path
+        android:pathData="M76,41L80.87,54H87L82.13,41H76Z"
+        android:fillColor="#4C4C4C"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #26

## Work Description ✏️
- WebtoonsService 구현
- WebtoonsResponseDto 구현
- DayWbtoonsResponseDto 구현
- WebtoonsDataSource 구현
- WebtoonsDataSourceImpl 구현
- WebtoonsRepository 구현
- WebtoonsRepositoryImpl  구현
- SearchWebtoonsUsecase구현
- DataSourceModule -> WebtoonsDataSource + WebtoonsDataSourceImpl 바인딩
- RepositoryModule -> WebtoonsRepository + WebtoonsRepositoryImpl 바인딩
- empty card view 추가


## Screenshot 📸

https://github.com/user-attachments/assets/3dcaa3a9-16e3-4600-8446-62a4f62818c1



## Uncompleted Tasks 😅
- [ ] 서버와 검색로직 상의

## To Reviewers 📢
한글 특성상 자음,모음이 나누어져 있어 한 글자가 완성되어야 검색이 됩니다.
이는 서버와 상의해보겠습니다!

서버 리소스가 제한적이라 모든 검색결과의 이미지Url을 넣지 못한다고하여 Empty card 피그마로 제작해 이미지 추가해두었습니다.
<img width="614" alt="image" src="https://github.com/user-attachments/assets/195d603e-9f3a-4f2c-b14c-04aeb960b7d3">
